### PR TITLE
Remove py from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ commonmark==0.9.1
 iniconfig==1.1.1
 packaging==21.3
 pluggy==1.0.0
-py==1.11.0
 Pygments==2.12.0
 pyparsing==3.0.9
 pytest==7.1.2


### PR DESCRIPTION
Removed a vulnerable package from requirements.txt.  If the package is installed within a dependency of this package, it should be uninstalled and removed.